### PR TITLE
Add a collection ID to the wp_cache key

### DIFF
--- a/public/includes/components/component-collections.php
+++ b/public/includes/components/component-collections.php
@@ -96,12 +96,12 @@ if (!function_exists('aesop_collection_shortcode')){
 								);
 
 								// get cached query
-								$query = wp_cache_get('aesop_collection_query');
+								$query = wp_cache_get('aesop_collection_query_' . $atts['collection'] );
 
 								// if no cached query then cache the query
 								if (false == $query ) {
 									$query = new wp_query( apply_filters( 'aesop_collection_query', $args ) );
-									wp_cache_set('aesop_collection_query', $query);
+									wp_cache_set('aesop_collection_query_' . $atts['collection'] , $query);
 								}
 
 								// loop through the stories


### PR DESCRIPTION
- Create one cache for each shortcode (aesop_collectio)n using the collection ID.

BUG: When you use the shortcode twice:

´´´
[aesop_collection title="xx" collection="1" columns="4"]
[aesop_collection title="xx" collection="2" columns="4"]
´´´

The posts for the first collection are used again, this is because the wp_cache.
