### PR TITLE
Disable youtube recommendations at end of video

### DIFF
--- a/public/includes/components/component-video.php
+++ b/public/includes/components/component-video.php
@@ -106,7 +106,7 @@ if (!function_exists('aesop_video_shortcode')){
 	                break;
 
 	            case 'youtube':
-	                printf( '<iframe src="//www.youtube.com/embed/%s" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',$atts['id'], $iframe_size );
+	                printf( '<iframe src="//www.youtube.com/embed/%s?rel=0" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',$atts['id'], $iframe_size );
 	                break;
 
 	            case 'kickstarter':


### PR DESCRIPTION
Hi Nick,

we're quite happily using AESOP in a few of our projects, along with a few small and some more or less intrusive modifications.

I'll start to clean up and package pull requests for the changes I think a greater user base would benefit from - you're free to ignore them, of course, but if you merge them, the update process for us will become easier :)
Here's the first one of more to come:

Normally, the embedded youtube player will show recommended videos based
on the one played.
This isn't however desired if we want the reader to submerge into a
long, distraction-free reading/viewing experience, so we've disabled the
video recommendations for our projects. I even think this would make a
good default for AESOP.

Thank you,
Artjom
