### PR TITLE
Disable youtube recommendations at end of video

### DIFF
--- a/public/includes/components/component-video.php
+++ b/public/includes/components/component-video.php
@@ -106,7 +106,7 @@ if (!function_exists('aesop_video_shortcode')){
 	                break;
 
 	            case 'youtube':
-	                printf( '<iframe src="//www.youtube.com/embed/%s" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',$atts['id'], $iframe_size );
+	                printf( '<iframe src="//www.youtube.com/embed/%s?rel=0" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',$atts['id'], $iframe_size );
 	                break;
 
 	            case 'kickstarter':


### PR DESCRIPTION
Normally, the embedded youtube player will show recommended videos based
on the one played.
This isn't however desired if we want the reader to submerge into a
long, distraction-free reading/viewing experience, so we've disabled the
video recommendations for our projects. I even think this would make a
good default for AESOP.
