### PR TITLE
Fix: Youtube embed in IE ignores z-index values

### DIFF
--- a/public/includes/components/component-video.php
+++ b/public/includes/components/component-video.php
@@ -96,7 +96,7 @@ if (!function_exists('aesop_video_shortcode')){
 		                printf( '<iframe src="//www.dailymotion.com/embed/video/%s" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',esc_attr( $atts['id'] ), esc_attr( $iframe_size ) );
 		                break;
 		            case 'youtube':
-		                printf( '<iframe src="//www.youtube.com/embed/%s?rel=0" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',esc_attr($atts['id']), esc_attr($iframe_size) );
+		                printf( '<iframe src="//www.youtube.com/embed/%s?rel=0&wmode=transparent" %s  webkitAllowFullScreen mozallowfullscreen allowFullScreen wmode="transparent" frameborder="0"></iframe>',esc_attr($atts['id']), esc_attr($iframe_size) );
 		                break;
 		            case 'kickstarter':
 		                printf( '<iframe src="%s" %s scrolling="no"> </iframe>',esc_attr( $atts['id'] ), esc_attr( $iframe_size ) );


### PR DESCRIPTION
In Internet Explorer 11 (most probably 10 and below, too), when embedding a Youtube video which relies on the flash player to be played, we noticed that the player object stays on top of all other objects: header bar and even the IE11 scroll bar when the width is set to 100%.

This seems to be a well-known problem: http://stackoverflow.com/questions/9074365/youtube-video-embedded-via-iframe-ignoring-z-index

Apparently, setting wmode="transparent" on the iframe (as it already is) isn't enough.
By providing the URL parameter "?wmode=transparent", the flash object (<embed> element) in the iframe will get the parameter wmode="transparent", which solves the issue.
