### PR TITLE
Chapter title attribute on wrong element

### DIFF
--- a/public/includes/components/component-heading.php
+++ b/public/includes/components/component-heading.php
@@ -66,7 +66,8 @@ if ( ! function_exists( 'aesop_chapter_shortcode' ) ) {
 
 ?>
 			<div id="chapter-unique-<?php echo $unique;?>" <?php echo aesop_component_data_atts( 'chapter', $unique, $atts );?> class="aesop-article-chapter-wrap default-cover <?php echo $video_chapter_class;?> aesop-component <?php echo $img_style_class;?> <?php echo $full_class;?> " 
-			    <?php echo aesop_revealfx_set($atts) ? 'style="visibility:hidden;"': null ?>
+			    <?php echo aesop_revealfx_set($atts) ? 'style="visibility:hidden;"': null ?> 
+			    data-title="<?php echo esc_attr( $atts['title'] );?>"
 			>
 
 				<?php do_action( 'aesop_chapter_inside_top', $atts, $unique ); // action ?>
@@ -74,7 +75,7 @@ if ( ! function_exists( 'aesop_chapter_shortcode' ) ) {
 				<div class="aesop-article-chapter clearfix" <?php echo $img_style;?> >
 
 				    <?php if (empty($atts['overlay_content'])) { ?>
-					<h2 class="aesop-cover-title" itemprop="title" data-title="<?php echo esc_attr( $atts['title'] );?>">
+					<h2 class="aesop-cover-title" itemprop="title">
 						<span><?php echo esc_html( $atts['title'] );?></span>
 
 						<?php if ( $atts['subtitle'] ) { ?>


### PR DESCRIPTION
The attribute `data-title` is expected to be on the `aesop-article-chapter-wrap` container but instead was added to the `<h2>` title element.

Line 177: `var title = jQuery(this).find('.aesop-article-chapter-wrap').attr('data-title');`

The `<h2>` title element does not always exist on the page. For example, if a user adds custom "Overlay Text" for a chapter element the title is not include in the page output. Because this `data-title` attribute is in the wrong place, and sometimes missing entirely, the full title and sub-title text are being applied to the chapter navigation menu. If Overlay Content is added, this full text appears in the chapter navigation menu instead.

This behavior is counter to the description in the help text:

>Overlay Content - Text or HTML content to be displayed. You can use tags like H2, H3 etc. Important: If set, it will not show title and subtitle. The chapter menu will still use what you put in for Title.

Regardless of the content entered in the Overlay Content area, the chapter title entered should be used in the navigation. This isn't possible if the `data-title` attribute is not on the page or applied to the wrong container. Moving the attribute to the expected container fixes the problem.