### PR TITLE
Removed redundant symbols '?>' in the inline CSS

### DIFF
--- a/public/includes/components/component-parallax.php
+++ b/public/includes/components/component-parallax.php
@@ -205,7 +205,7 @@ if ( ! function_exists( 'aesop_parallax_shortcode' ) ) {
 					<?php
 					} else {
 				    ?>
-						<div class="aesop-stacked-img" style="background-attachment: fixed;height:100%;background-image:url('<?php echo esc_url( $atts['img'] );?>');background-size:cover;background-position:center center;?>">
+						<div class="aesop-stacked-img" style="background-attachment: fixed;height:100%;background-image:url('<?php echo esc_url( $atts['img'] );?>');background-size:cover;background-position:center center;">
 						</div>
 					<?php
 					}


### PR DESCRIPTION
Redundant symbols '?>' in the inline CSS for parallax elements with fixed image can lead to parallax effect break in some browsers