### PR TITLE
Fix for fixed position parallax in Firefox

### DIFF
--- a/public/assets/less/components.less
+++ b/public/assets/less/components.less
@@ -53,6 +53,7 @@
     position: relative;
     overflow: hidden;
     -webkit-transform: translate3d(0px, 0px, 0px);
+    -moz-transform: unset;
     height:400px;
 
     .aesop-parallax-sc-img {


### PR DESCRIPTION
Firefox seems to be reading the `-webkit-transform: translate3d(0px, 0px, 0px);` property and causing fixed position parallax images to display as static position and scroll normally.