### PR TITLE
Fix for undefined error

### DIFF
--- a/admin/includes/generator_blob.php
+++ b/admin/includes/generator_blob.php
@@ -79,7 +79,9 @@ function aesop_shortcodes_blob() {
 		$return .= '<input type="hidden" name="aesop-generator-result" id="aesop-generator-result" value="" />';
 
 		// extra JS codes
-		$return .= $shortcode['codes'];
+		if ( isset( $shortcode['codes'] ) ) :
+			$return .= $shortcode['codes'];
+		endif;
 		
 		
 		$blob[$slug] = $return;


### PR DESCRIPTION
With `WP_DEBUG` enabled, the index `codes` throws an error if not defined:

```
Notice: Undefined index: codes in aesop-story-engine/admin/includes/generator_blob.php on line 82
```

Wrapping it in an `isset()` check fixes that.