### PR TITLE
Refactored to use `has_blocks`

### DIFF
--- a/public/includes/theme-helpers.php
+++ b/public/includes/theme-helpers.php
@@ -60,12 +60,12 @@ function aesop_component_exists( $component = '' ) {
 		return true;
 
 	} else {
-		if (  function_exists( 'gutenberg_content_has_blocks' ) ) {
+		if (  function_exists( 'has_blocks' ) ) {
 			if ($component == 'timeline_stop') {
 				$component = 'timeline';
 			}
 			// if Gutenberg is on, check for Aesop Gutenberg blocks
-			if (  gutenberg_content_has_blocks( $post->post_content ) ) {
+			if ( has_blocks( $post->post_content ) ) {
 				// check if the given Aesop block exists
 				$blocks = gutenberg_parse_blocks($post->post_content );
 				foreach ($blocks as &$block) {


### PR DESCRIPTION
The function `gutenberg_content_has_blocks` is deprecated as of version 3.6.0. The discussion leading up to the change can be found [here](https://github.com/WordPress/gutenberg/issues/4418) and the PR which was merged 2 days ago can be found [here](https://github.com/WordPress/gutenberg/pull/8631).