### PR TITLE
Fixed another Gutenberg error

### DIFF
--- a/public/includes/theme-helpers.php
+++ b/public/includes/theme-helpers.php
@@ -69,7 +69,7 @@ function aesop_component_exists( $component = '' ) {
 				// check if the given Aesop block exists
 				$blocks = gutenberg_parse_blocks($post->post_content );
 				foreach ($blocks as &$block) {
-					if ( array_key_exists('blockName', $block) && $block['blockName'] == 'ase/'.$component ) {
+					if ( is_array( $block ) && array_key_exists('blockName', $block) && $block['blockName'] == 'ase/'.$component ) {
 						return true;
 					}
 				}


### PR DESCRIPTION
Added `is_array()` check to fix error: `Cannot use object of type WP_Block_Parser_Block as array`