### PR TITLE
only autostart videos if they are visible

### DIFF
--- a/public/includes/components/component-video.php
+++ b/public/includes/components/component-video.php
@@ -312,7 +312,9 @@ if ( ! function_exists( 'aesop_video_shortcode' ) ) {
 										$('#aesop-video-<?php echo esc_attr( $unique );?>').waypoint({
 											offset: '30%',
 											handler: function(direction){
-												aseYTBplayer<?php echo esc_attr( $instance );?>.playVideo();
+												if ( $(this.element).is(':visible') ) {
+													aseYTBplayer<?php echo esc_attr( $instance );?>.playVideo();
+												}
 											}
 										});
 										


### PR DESCRIPTION
otherwise hidden videos (e.g. inside collaped details elements)
will get started already on page load (due to waypoints for these
elements fire on page start because their offset is zero).